### PR TITLE
Add bench test for get rlock

### DIFF
--- a/skiplist.go
+++ b/skiplist.go
@@ -53,8 +53,8 @@ func (list *SkipList) Set(key float64, value interface{}) *Element {
 // Get finds an element by key. It returns element pointer if found, nil if not found.
 // Locking is optimistic and happens only after searching with a fast check for deletion after locking.
 func (list *SkipList) Get(key float64) *Element {
-	list.mutex.Lock()
-	defer list.mutex.Unlock()
+	list.mutex.RLock()
+	defer list.mutex.RUnlock()
 
 	var prev *elementNode = &list.elementNode
 	var next *Element

--- a/skiplist_test.go
+++ b/skiplist_test.go
@@ -3,6 +3,7 @@ package skiplist
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"unsafe"
 )
@@ -229,4 +230,21 @@ func BenchmarkDecGet(b *testing.B) {
 	}
 
 	b.SetBytes(int64(b.N))
+}
+
+func BenchmarkIncGetParallel(b *testing.B) {
+	b.ReportAllocs()
+	var t int64
+	b.RunParallel(func(pb *testing.PB) {
+		var i int64
+		for i = 0; pb.Next(); i++ {
+			res := benchList.Get(float64(i % 1e7))
+			if res == nil {
+				b.Fatal("failed to Get an element that should exist")
+			}
+		}
+		atomic.AddInt64(&t, i)
+	})
+
+	b.SetBytes(t)
 }


### PR DESCRIPTION
```
name               old time/op    new time/op     delta
IncSet-12             277ns ± 8%      277ns ± 7%       ~     (p=0.780 n=10+10)
IncGet-12             154ns ± 2%      164ns ± 2%     +6.09%  (p=0.000 n=10+10)
DecSet-12             173ns ± 3%      175ns ± 5%       ~     (p=0.724 n=10+10)
DecGet-12             160ns ± 3%      166ns ± 1%     +3.69%  (p=0.000 n=10+9)
IncGetParallel-12     263ns ± 1%       39ns ± 5%    -85.35%  (p=0.000 n=8+10)

name               old speed      new speed       delta
IncSet-12          16.4TB/s ± 9%   16.4TB/s ± 8%       ~     (p=0.780 n=10+9)
IncGet-12          58.9TB/s ± 3%   48.1TB/s ± 2%    -18.31%  (p=0.000 n=10+9)
DecSet-12          40.3TB/s ± 9%   40.4TB/s ± 4%       ~     (p=0.968 n=9+10)
DecGet-12          54.5TB/s ± 2%   45.4TB/s ± 9%    -16.82%  (p=0.000 n=9+10)
IncGetParallel-12  17.0TB/s ± 1%  836.3TB/s ±10%  +4817.85%  (p=0.000 n=8+9)

name               old alloc/op   new alloc/op    delta
IncSet-12             61.0B ± 0%      61.0B ± 0%       ~     (all equal)
IncGet-12             0.00B           0.00B            ~     (all equal)
DecSet-12             61.0B ± 0%      61.0B ± 0%       ~     (all equal)
DecGet-12             0.00B           0.00B            ~     (all equal)
IncGetParallel-12     0.00B           0.00B            ~     (all equal)

name               old allocs/op  new allocs/op   delta
IncSet-12              3.00 ± 0%       3.00 ± 0%       ~     (all equal)
IncGet-12              0.00            0.00            ~     (all equal)
DecSet-12              3.00 ± 0%       3.00 ± 0%       ~     (all equal)
DecGet-12              0.00            0.00            ~     (all equal)
IncGetParallel-12      0.00            0.00            ~     (all equal)
```